### PR TITLE
Remove unnecessary tag reselection in tag_get_uid() for both nem_execute and nem_dbus modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,29 @@
+# Autotools generated files
+/autom4te.cache/
+/aclocal.m4
+/compile
+/config.guess
+/config.h.in
+/config.sub
+/configure
+/depcomp
+/install-sh
+/ltmain.sh
+/missing
+/m4/
+INSTALL
+/Makefile.in
+/conf/Makefile.in
+/src/Makefile.in
+/src/debug/Makefile.in
+/src/modules/Makefile.in
+/src/nfcconf/Makefile.in
+
+# Build artifacts
+config.log
+config.status
+configure~
+*~
+
+# CodeQL
+_codeql_detected_source_root

--- a/README
+++ b/README
@@ -1,0 +1,19 @@
+# nfc-eventd
+
+NFC Event Daemon - A daemon that monitors NFC device for tag insertions/removals.
+
+## Building the Debian Package
+
+To build the .deb package from source:
+
+```bash
+dpkg-buildpackage -us -uc
+```
+
+This will create the package files in the parent directory without signing them.
+
+## Description
+
+nfc-eventd is a daemon that looks for tag insertions/removes from NFC device.
+It is provided with two NEM (NFC Event Modules) which allow many kinds of
+usage of these events.

--- a/README.md
+++ b/README.md
@@ -2,11 +2,14 @@
 
 NFC Event Daemon - A daemon that monitors NFC device for tag insertions/removals.
 
+[Archived Wiki Page](https://web.archive.org/web/20200630215251/http://nfc-tools.org/index.php/Nfc-eventd)
+
 ## Building the Debian Package
 
 To build the .deb package from source:
 
 ```bash
+autoreconf -vis
 dpkg-buildpackage -us -uc
 ```
 

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Homepage: http://code.google.com/p/nfc-tools/
 
 Package: nfc-eventd
 Architecture: any
-Depends: ${shlibs:Depends}, libnfc2 (>= 1.5.1), libdbus-1-3, libdbus-glib-1-2
+Depends: ${shlibs:Depends}, libnfc6, libdbus-1-3, libdbus-glib-1-2
 Description: NFC event daemon
  nfc-eventd is a daemon that looks for tags insertions/removes from NFC device.
  It is provided with two NEM (Nfc Eventd Modules) which allow many kind of

--- a/src/modules/nem_dbus.c
+++ b/src/modules/nem_dbus.c
@@ -39,26 +39,21 @@ void
 tag_get_uid(nfc_device* nfc_device, const nfc_target* tag, char **dest) {
   DBG("tag_get_uid(%08x, %08x, %08x)", nfc_device, tag, dest);
 
-    nfc_target target;
     debug_print_tag(tag);
-    /// @TODO We don't need to reselect tag to get his UID: nfc_target contains this data.
-    // Poll for a ISO14443A (MIFARE) tag
-    if ( nfc_initiator_select_passive_target ( nfc_device, tag->nm, tag->nti.nai.abtUid, tag->nti.nai.szUidLen, &target ) ) {
-        *dest = malloc(target.nti.nai.szUidLen*sizeof(char));
-        size_t szPos;
-        char *pcUid = *dest;
-        for (szPos=0; szPos < target.nti.nai.szUidLen; szPos++) {
-            sprintf(pcUid, "%02x",target.nti.nai.abtUid[szPos]);
-            pcUid += 2;
-        }
-        pcUid[0]='\0';
-        DBG( "ISO14443A (MIFARE) tag found: uid=0x%s", *dest );
-        nfc_initiator_deselect_target ( nfc_device );
-    } else {
-        *dest = NULL;
-        DBG("%s", "ISO14443A (MIFARE) tag not found" );
+    // Extract UID directly from nfc_target - no need to reselect
+    *dest = malloc(tag->nti.nai.szUidLen*sizeof(char)*2+1);
+    if (*dest == NULL) {
+        ERR("%s", "Unable to allocate memory for tag UID");
         return;
     }
+    size_t szPos;
+    char *pcUid = *dest;
+    for (szPos=0; szPos < tag->nti.nai.szUidLen; szPos++) {
+        sprintf(pcUid, "%02x",tag->nti.nai.abtUid[szPos]);
+        pcUid += 2;
+    }
+    pcUid[0]='\0';
+    DBG( "ISO14443A (MIFARE) tag found: uid=0x%s", *dest );
 }
 
 static void lose (const char *fmt, ...) G_GNUC_NORETURN G_GNUC_PRINTF (1, 2);

--- a/src/modules/nem_execute.c
+++ b/src/modules/nem_execute.c
@@ -98,24 +98,20 @@ void
 tag_get_uid(nfc_device* nfc_device, nfc_target* tag, char **dest) {
   debug_print_tag(tag);
 
-  /// @TODO We don't need to reselect tag to get his UID: nfc_target contains this data.
-  // Poll for a ISO14443A (MIFARE) tag
-  if ( nfc_initiator_select_passive_target ( nfc_device, tag->nm, tag->nti.nai.abtUid, tag->nti.nai.szUidLen, tag ) ) {
-      *dest = malloc(tag->nti.nai.szUidLen*sizeof(char)*2+1);
-      size_t szPos;
-      char *pcUid = *dest;
-      for (szPos=0; szPos < tag->nti.nai.szUidLen; szPos++) {
-          sprintf(pcUid, "%02x",tag->nti.nai.abtUid[szPos]);
-          pcUid += 2;
-      }
-      pcUid[0]='\0';
-      DBG( "ISO14443A tag found: UID=0x%s", *dest );
-      nfc_initiator_deselect_target ( nfc_device );
-  } else {
-      *dest = NULL;
-      DBG("%s", "ISO14443A (MIFARE) tag not found" );
+  // Extract UID directly from nfc_target - no need to reselect
+  *dest = malloc(tag->nti.nai.szUidLen*sizeof(char)*2+1);
+  if (*dest == NULL) {
+      ERR("%s", "Unable to allocate memory for tag UID");
       return;
   }
+  size_t szPos;
+  char *pcUid = *dest;
+  for (szPos=0; szPos < tag->nti.nai.szUidLen; szPos++) {
+      sprintf(pcUid, "%02x",tag->nti.nai.abtUid[szPos]);
+      pcUid += 2;
+  }
+  pcUid[0]='\0';
+  DBG( "ISO14443A tag found: UID=0x%s", *dest );
 }
 
 int
@@ -172,7 +168,7 @@ nem_execute_event_handler(nfc_device* nfc_device, nfc_target* tag, const nem_eve
     // DBG ( "Onerror is set to: '%s'", onerrorstr );
 
     if ( _tag_uid == NULL ) {
-        ERR( "%s", "Unable to read tag UID... This should not happend !" );
+        ERR( "%s", "Unable to read tag UID... This should not happen!" );
         switch ( onerr ) {
         case ONERROR_IGNORE:
             break;


### PR DESCRIPTION
* Add .gitignore to exclude autotools generated files
* Add README with build instructions 
* update debian/control to depend on libnfc6

Code changes made by GitHub Copilot

Probably fixes #5 and similar flakiness I encountered